### PR TITLE
fix: Improve type prefix and suffix extraction 

### DIFF
--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -80,15 +80,12 @@ def from_uuid(suffix: uuid6.UUID, prefix: Optional[str] = None) -> TypeID:
 
 
 def get_prefix_and_suffix(string: str) -> tuple:
-    parts = string.split("_")
-    prefix = None
+    parts = string.rsplit("_", 1)
     if len(parts) == 1:
+        prefix = None
         suffix = parts[0]
-    elif len(parts) == 2 and parts[0] != "":
-        suffix = parts[1]
-        prefix = parts[0]
     else:
-        raise InvalidTypeIDStringException(f"Invalid TypeID: {string}")
+        prefix, suffix = parts
 
     return prefix, suffix
 


### PR DESCRIPTION
Refactored the logic in `get_prefix_and_suffix` function to improve type
prefix and suffix extraction. Now using `rsplit` method to accurately extract
the prefix and suffix from the input string. 

Closes #12